### PR TITLE
Copy files if they cannot be hardlinked

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,10 +3,17 @@ use strict;
 require 5.006;
 
 use ExtUtils::MakeMaker;
+use File::Copy;
+
+sub link_or_copy {
+  my ($source, $dest) = @_;
+
+  link($source, $dest) or copy($source, $dest);
+}
 
 my @exe;
 unless (exists $ENV{AUTOMATED_TESTING} and $ENV{AUTOMATED_TESTING} == 1) {
-    -f "examples/xlsgrep" or link "examples/xlscat", "examples/xlsgrep";
+    -f "examples/xlsgrep" or link_or_copy "examples/xlscat", "examples/xlsgrep";
     for ( [ "xlscat",	"Convert Spreadsheet to plain text or CSV"	],
 	  [ "xlsgrep",	"Grep pattern from Spreadsheet"			],
 	  [ "ss2tk",	"Show a Spreadsheet in Perl/Tk"			],


### PR DESCRIPTION
In some cases, hard links are not available.  The `xlsgrep` and `xlscat`
programs are actually the same script and Makefile.PL links them as
such.  Since both items are installed by default in a non-interactive
installation, if the hard link fails, building the module will also
fail.  If for whatever reason we are not able to hard link the files, we
should try just copying them as a backup.

I initially thought using a symbolic link would be a good backup choice
but I am not aware of a portable way to do that.
