### PR TITLE
Updates to support Spreadsheet::XLSX::Reader::LibXML v0.38.18

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,6 +52,7 @@ my %wm = (
 #	"Spreadsheet::ParseXLSX"	=> 0.13,
 #	"Spreadsheet::XLSX"		=> 0.13,
 #	"Spreadsheet::Perl"		=> 0,	# Not yet
+#	"Spreadsheet::XLSX::Reader::LibXML"	=> v0.38.18,	# Not yet
 
 	# For testing
 	"Test::More"			=> 0.88,

--- a/Read.pm
+++ b/Read.pm
@@ -46,7 +46,7 @@ my @parsers = (
     [ xls  => "Spreadsheet::ParseExcel",		"0.34"		],
     [ xlsx => "Spreadsheet::ParseXLSX",			"0.13"		],
     [ xlsx => "Spreadsheet::XLSX",			"0.13"		],
-    [ xlsx => "Spreadsheet::XLSX::Reader::LibXML",	"v0.38.14"	],
+    [ xlsx => "Spreadsheet::XLSX::Reader::LibXML",	"v0.38.18"	],
     [ prl  => "Spreadsheet::Perl",			""		],
 
     # Helper modules

--- a/t/633_misc.t
+++ b/t/633_misc.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-
+use Spreadsheet::XLSX::Reader::LibXML v0.38.18;
 BEGIN { $ENV{SPREADSHEET_READ_XLSX} = "Spreadsheet::XLSX::Reader::LibXML"; }
 
 my     $tests = 5;

--- a/t/633_misc.t
+++ b/t/633_misc.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Spreadsheet::XLSX::Reader::LibXML v0.38.18;
+#~ use Spreadsheet::XLSX::Reader::LibXML v0.38.18;
 BEGIN { $ENV{SPREADSHEET_READ_XLSX} = "Spreadsheet::XLSX::Reader::LibXML"; }
 
 my     $tests = 5;

--- a/t/635_perc.t
+++ b/t/635_perc.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Spreadsheet::XLSX::Reader::LibXML v0.38.18;
+#~ use Spreadsheet::XLSX::Reader::LibXML v0.38.18;
 BEGIN { $ENV{SPREADSHEET_READ_XLSX} = "Spreadsheet::XLSX::Reader::LibXML"; }
 
 my     $tests = 77;

--- a/t/635_perc.t
+++ b/t/635_perc.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-
+use Spreadsheet::XLSX::Reader::LibXML v0.38.18;
 BEGIN { $ENV{SPREADSHEET_READ_XLSX} = "Spreadsheet::XLSX::Reader::LibXML"; }
 
 my     $tests = 77;
@@ -23,11 +23,11 @@ ok ($xls, "Excel Percentage testcase");
 my $ss   = $xls->[1];
 my $attr = $ss->{attr};
 
-my $type = $pv le "v0.38.8" ? "numeric" : "percentage";
+#~ my $type = $pv le "v0.38.8" ? "numeric" : "percentage";
 foreach my $row (1 .. 19) {
     is ($ss->{attr}[1][$row]{type}, "numeric",	"Type A$row numeric");
-    is ($ss->{attr}[2][$row]{type}, $type,	"Type B$row percentage");
-    is ($ss->{attr}[3][$row]{type}, $type,	"Type C$row percentage");
+    is ($ss->{attr}[2][$row]{type}, "percentage",	"Type B$row percentage");# not $type
+    is ($ss->{attr}[3][$row]{type}, "percentage",	"Type C$row percentage");# not $type
 
     SKIP: {
 	$ss->{B18} =~ m/[.]/ and


### PR DESCRIPTION
Tux,

I just pushed Spreadsheet::XLSX::Reader::LibXML v0.38.18 to github and I acknowledge that the last push (v0.38.16) broke as much as it fixed.  In part my reliance on just my test suit was unfounded.  As a consequence I have run your test suit as well with v0.38.18 installed and it passes all but the pod test with the following changes.  Please consider them or something like them for continued support of Spreadsheet::XLSX::Reader::LibXML.

Best Regards,

Jed
