### PR TITLE
localize $_ before assignment

### DIFF
--- a/Read.pm
+++ b/Read.pm
@@ -520,7 +520,7 @@ sub ReadData {
 	if ($io_fil) {
 	    unless (defined $opt{quote} && defined $opt{sep}) {
 		open $in, "<", $txt or return;
-		$_ = <$in>;
+		local $_ = <$in>;
 
 		$quo = defined $opt{quote} ? $opt{quote} : '"';
 		$sep = # If explicitly set, use it


### PR DESCRIPTION
Fixes:
 my $file = 'files/blank.csv';
 ReadData($_) foreach ($file);
 print $file; # prints ',,,'