### PR TITLE
xls2csv: use do to execute xlscat

### DIFF
--- a/examples/xls2csv
+++ b/examples/xls2csv
@@ -73,4 +73,9 @@ if (-f $csv) {
 
 warn "Converting $xls to $csv ...\n";
 open STDOUT, ">", $csv or die "$csv: $!\n";
-exec "xlscat", "-c", @ARGV, $xls;
+{   package XLSCAT;
+    require File::Spec;
+    local @INC = File::Spec->path;
+    local @ARGV = ('-c', @ARGV, $xls);
+    do 'xlscat';
+    }


### PR DESCRIPTION
Due to how Windows passes arguments to programs, dealing with arguments
with whitespace is tricky and perl's exec function does not do it
correctly.  Any arguments with whitespace get split by the exec'd
process.  The exec'd process also appears to fork causing the command
prompt to reappear only to immediately be covered in error output from
xlscat due to the bad arguments.

Fortunately, since xlscat is just another perl script, we can run it
directly in the existing perl process.

Some references on Windows argument passing:
https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
http://blogs.perl.org/users/graham_knop/2011/12/using-system-or-exec-safely-on-windows.html