### PR TITLE
Fix test suite errors caused by Spreadsheet::ReadXSC 0.22, allow reading from filehandles

### DIFF
--- a/Read.pm
+++ b/Read.pm
@@ -893,15 +893,21 @@ sub ReadData {
     if ($opt{parser} ? _parser ($opt{parser}) eq "sxc"
 		     : ($txt =~ m/^<\?xml/ or -f $txt)) {
 	$can{sxc} or croak "Spreadsheet::ReadSXC not installed";
-	ref $txt and
-	    croak ("Sorry, references as input are not (yet) supported by Spreadsheet::ReadSXC");
 
+    if (ref $txt and $can{sxc}->VERSION <= 0.23) {
+	    croak ("Sorry, references as input are not supported by Spreadsheet::ReadSXC before 0.23");
+    }
 	my $using = "using $can{sxc}-" . $can{sxc}->VERSION;
 	my $sxc_options = { %parser_opts, OrderBySheet => 1 }; # New interface 0.20 and up
 	my $sxc;
 	   if ($txt =~ m/\.(sxc|ods)$/i) {
 	    $debug and print STDERR "Opening \U$1\E $txt $using\n";
 	    $sxc = Spreadsheet::ReadSXC::read_sxc      ($txt, $sxc_options)	or  return;
+	    }
+	# treat all refs as a filehandle
+	elsif (ref $txt) {
+	    $debug and print STDERR "Opening SXC filehandle\n";
+	    $sxc = Spreadsheet::ReadSXC::read_sxc_fh($txt, $sxc_options);
 	    }
 	elsif ($txt =~ m/\.xml$/i) {
 	    $debug and print STDERR "Opening XML $txt $using\n";

--- a/t/40_sxc.t
+++ b/t/40_sxc.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-my     $tests = 301;
+my     $tests = 401;
 use     Test::More;
 require Test::NoWarnings;
 
@@ -30,13 +30,26 @@ my $content;
     #like ($@, qr/too short/);
     }
 
+my $sxc_fh;
+{   open $sxc_fh, '<', "files/test.sxc" or die "files/test.sxc: $!\n";
+    }
 foreach my $base ( [ "files/test.sxc",		"Read/Parse sxc file" ],
 		   [ "files/content.xml",	"Read/Parse xml file" ],
 		   [ $content,			"Parse xml data" ],
+		   [ $sxc_fh,			"Parse FH" ],
 		   ) {
     my ($txt, $msg) = @$base;
     my $sxc;
-    ok ($sxc = ReadData ($txt), $msg);
+    my @options = ref $txt ? ( parser => "sxc"): ();
+
+    if (ref $txt and (my $v = $parser->VERSION) <= 0.23 ) {
+        SKIP: {
+            skip "$parser $v does not support filehandles", 100;
+        };
+        next;
+    };
+
+    ok ($sxc = ReadData ($txt, @options), $msg);
 
     ok (1, "Base values");
     is (ref $sxc,		"ARRAY",	"Return type");
@@ -80,7 +93,7 @@ foreach my $base ( [ "files/test.sxc",		"Read/Parse sxc file" ],
     ok (1, "Sheet 2");
     # Sheet with merged cells and notes/annotations
     # x   x   x
-    #   x   x 
+    #   x   x
     # x   x   x
 
     ok (1, "Defined fields");

--- a/t/46_clr.t
+++ b/t/46_clr.t
@@ -11,7 +11,7 @@ use Spreadsheet::Read;
 my $parser = Spreadsheet::Read::parses ("ods") or
     plan skip_all => "No OpenOffice ODS parser found";
 
-$parser->VERSION <= 0.20 and
+$parser->VERSION <= 0.40 and
     plan skip_all => "Spreadsheet::ReadSXC version " . $parser->VERSION .
 		    " doesn't support field attributes";
 


### PR DESCRIPTION
Spreadsheet::ReadXSC now allows reading from filehandles, so the warning can be removed.

This patch also adds tests for reading from filehandles for ODS and SXC files.

Version 0.23 of Spreadsheet::ReadSXC will be released this evening or tomorrow.