### PR TITLE
Avoid stricture error on Archive::Zip::AZ_OK being a bareword

### DIFF
--- a/scripts/xls2csv
+++ b/scripts/xls2csv
@@ -142,7 +142,7 @@ if ($opt_A || $opt_Z) {
 	my $fn = "$xls.zip";
 	-f $fn && $opt_f and unlink $fn;
 	-f $fn and die "$fn already exists\n";
-	$az->writeToFileNamed ($fn) == Archive::Zip::AZ_OK or die "$fn: $!\n";
+	$az->writeToFileNamed ($fn) == Archive::Zip::AZ_OK() or die "$fn: $!\n";
 	}
     exit;
     }

--- a/scripts/xlsx2csv
+++ b/scripts/xlsx2csv
@@ -142,7 +142,7 @@ if ($opt_A || $opt_Z) {
 	my $fn = "$xls.zip";
 	-f $fn && $opt_f and unlink $fn;
 	-f $fn and die "$fn already exists\n";
-	$az->writeToFileNamed ($fn) == Archive::Zip::AZ_OK or die "$fn: $!\n";
+	$az->writeToFileNamed ($fn) == Archive::Zip::AZ_OK() or die "$fn: $!\n";
 	}
     exit;
     }


### PR DESCRIPTION
I haven't checked why this didn't surface before. I last used xls2csv about 7-8 months ago and it was okay back then.