### PR TITLE
Use /usr/bin/perl as a standard shebang

### DIFF
--- a/Read.pm
+++ b/Read.pm
@@ -1,4 +1,4 @@
-#!/pro/bin/perl
+#!/usr/bin/perl
 
 package Spreadsheet::Read;
 

--- a/examples/ss-dups-tk.pl
+++ b/examples/ss-dups-tk.pl
@@ -1,4 +1,4 @@
-#!/pro/bin/perl
+#!/usr/bin/perl
 
 # ss-dup-tk.pl: Find dups in spreadsheet
 #	  (m)'18 [28-03-2018] Copyright H.M.Brand 2005-2023

--- a/scripts/ss2tk
+++ b/scripts/ss2tk
@@ -1,4 +1,4 @@
-#!/pro/bin/perl
+#!/usr/bin/perl
 
 # ss2tk: show SpreadSheet file in Tk::TableMatrix::Spreadsheet (*)
 #	  (m)'22 [2022-01-31] Copyright H.M.Brand 2005-2023

--- a/scripts/ssdiff
+++ b/scripts/ssdiff
@@ -1,4 +1,4 @@
-#!/pro/bin/perl
+#!/usr/bin/perl
 
 use 5.014000;
 use warnings;

--- a/scripts/xls2csv
+++ b/scripts/xls2csv
@@ -1,4 +1,4 @@
-#!/pro/bin/perl
+#!/usr/bin/perl
 
 # xls2csv: Convert supported spreadsheet formats to CSV
 #	   (m)'23 [2023-01-04] Copyright H.M.Brand 2008-2023

--- a/scripts/xlscat
+++ b/scripts/xlscat
@@ -1,4 +1,4 @@
-#!/pro/bin/perl
+#!/usr/bin/perl
 
 # xlscat:  show supported spreadsheet file as Text
 # xlsgrep: grep pattern

--- a/scripts/xlsgrep
+++ b/scripts/xlsgrep
@@ -1,4 +1,4 @@
-#!/pro/bin/perl
+#!/usr/bin/perl
 
 # xlscat:  show supported spreadsheet file as Text
 # xlsgrep: grep pattern

--- a/scripts/xlsx2csv
+++ b/scripts/xlsx2csv
@@ -1,4 +1,4 @@
-#!/pro/bin/perl
+#!/usr/bin/perl
 
 # xls2csv: Convert supported spreadsheet formats to CSV
 #	   (m)'23 [2023-01-04] Copyright H.M.Brand 2008-2023


### PR DESCRIPTION
Background: for openSUSE we require the scripts and examples to have the standard path to perl as a shebang. So for this module we have a patch correcting the custom /pro/bin/perl shebang.

Whenever there are changes to these scripts close to the top the patch will fail and has to be updated.

I'm not sure what the purpose of the /pro/bin/perl shebang is, but if it's not necessary this is a kind request to use the standard path so that we can remove our patch.

See also https://build.opensuse.org/package/show/devel:languages:perl/perl-Spreadsheet-Read